### PR TITLE
Add datafusion python test

### DIFF
--- a/test_out_datafusion.py
+++ b/test_out_datafusion.py
@@ -1,0 +1,20 @@
+from datafusion import SessionContext
+from datetime import datetime
+
+d1 = datetime.now()
+
+ctx = SessionContext()
+
+df = ctx.register_csv("trips", "data")
+
+df = ctx.sql("""SELECT COUNT('transaction_id') as cnt,
+    date_part('month', to_timestamp(started_at)) as month
+  FROM trips
+  GROUP BY date_part('month', to_timestamp(started_at))
+""")
+
+df.show()
+
+d2 = datetime.now()
+print(d2-d1)
+


### PR DESCRIPTION
This adds a Python test for DataFusion so that we don't need to run Rust code. This makes the test more similar to the other tests.

I will add a DataFrame (instead of SQL) version of this test as well when I get the time.